### PR TITLE
Add yarn install command option on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A tool to quickly start developing with kintone
 ## Installation
 ```
 npm install -g git://github.com/kintone-labs/kintone-cli.git
+ or
+yarn global add git://github.com/kintone-labs/kintone-cli.git
 ```
 ## Quickstart
 To quickly start with a minimum project, follow the instruction [here](./quickstart.md)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

There is a case that we cannot install kintone-cli globally with `npm install -g git://xxx.git way` using the Node version after 15.0.0.
https://github.com/kintone-labs/kintone-cli/issues/45#issuecomment-993133410


## What

I added the command option using yarn.
`yarn global add git://github.com/kintone-labs/kintone-cli.git`

## Checklist

- [x] Read [README.md](https://github.com/kintone-labs/kintone-cli/blob/master/README.md)
- [x] Updated documentation if it is required.
- [x] Checked the behavior.
